### PR TITLE
Remove undesired `@testable` annotation.

### DIFF
--- a/Tests/HTTPHeaderParserTests/HTTPHeaderParserTests.swift
+++ b/Tests/HTTPHeaderParserTests/HTTPHeaderParserTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import HTTPHeaderParser
+import HTTPHeaderParser
 
 final class HTTPHeaderParserTests: XCTestCase {
     static let singleLink = """


### PR DESCRIPTION
These class tests public APIs - correct access level is one of the things it should test.